### PR TITLE
[feat] 웹 <-> 클라이언트 인터페이스 구현, OCR 파싱 API 오류 해결

### DIFF
--- a/data/src/main/java/com/nexters/misik/data/datasource/RemoteDataSource.kt
+++ b/data/src/main/java/com/nexters/misik/data/datasource/RemoteDataSource.kt
@@ -1,12 +1,11 @@
 package com.nexters.misik.data.datasource
 
 import com.nexters.misik.data.mapper.ReviewMapper.toModel
+import com.nexters.misik.data.model.OcrParsedResponse
 import com.nexters.misik.data.model.Review
 import com.nexters.misik.network.dto.request.GenerateReviewRequestDto
 import com.nexters.misik.network.dto.request.OcrParseRequestDto
 import com.nexters.misik.network.service.ReviewService
-import retrofit2.HttpException
-import java.io.IOException
 import javax.inject.Inject
 
 class RemoteDataSource @Inject constructor(
@@ -18,19 +17,6 @@ class RemoteDataSource @Inject constructor(
     suspend fun getReview(id: Long): Review =
         reviewService.getReview(id).toModel()
 
-    suspend fun getOcrParsedResponse(text: String): String {
-        try {
-            val response = reviewService.getOcrParsedResponse(OcrParseRequestDto(text))
-
-            if (!response.isSuccessful) {
-                throw HttpException(response)
-            }
-            return response.body()?.string()
-                ?: throw IllegalStateException("Response body is null")
-        } catch (e: IOException) {
-            throw IOException("Network error occurred", e)
-        } catch (e: Exception) {
-            throw RuntimeException("Unexpected error occurred", e)
-        }
-    }
+    suspend fun getOcrParsedResponse(text: String): OcrParsedResponse =
+        reviewService.getOcrParsedResponse(OcrParseRequestDto(text)).toModel()
 }

--- a/data/src/main/java/com/nexters/misik/data/mapper/ReviewMapper.kt
+++ b/data/src/main/java/com/nexters/misik/data/mapper/ReviewMapper.kt
@@ -1,8 +1,13 @@
 package com.nexters.misik.data.mapper
 
+import com.nexters.misik.data.model.OcrParsedItem
+import com.nexters.misik.data.model.OcrParsedResponse
 import com.nexters.misik.data.model.Review
+import com.nexters.misik.domain.ParsedEntity
+import com.nexters.misik.domain.ParsedOcr
 import com.nexters.misik.domain.ReviewEntity
 import com.nexters.misik.network.dto.response.GetReviewResponseDto
+import com.nexters.misik.network.dto.response.OcrParsedResponseDto
 
 object ReviewMapper {
     fun GetReviewResponseDto.toModel(): Review {
@@ -13,11 +18,33 @@ object ReviewMapper {
         )
     }
 
+    fun OcrParsedResponseDto.toModel(): OcrParsedResponse {
+        return OcrParsedResponse(
+            parsed = parsed.map {
+                OcrParsedItem(
+                    key = it.key,
+                    value = it.value,
+                )
+            },
+        )
+    }
+
     fun Review.toDomain(): ReviewEntity {
         return ReviewEntity(
             id = this.id,
             review = this.review,
             isSuccess = this.isSuccess,
+        )
+    }
+
+    fun OcrParsedResponse.toDomain(): ParsedEntity {
+        return ParsedEntity(
+            parsed = parsed.map {
+                ParsedOcr(
+                    key = it.key,
+                    value = it.value,
+                )
+            },
         )
     }
 }

--- a/data/src/main/java/com/nexters/misik/data/model/OcrParsedResponse.kt
+++ b/data/src/main/java/com/nexters/misik/data/model/OcrParsedResponse.kt
@@ -2,40 +2,7 @@ package com.nexters.misik.data.model
 
 data class OcrParsedResponse(
     val parsed: List<OcrParsedItem>,
-) {
-    companion object {
-        fun createMock(): OcrParsedResponse {
-            return OcrParsedResponse(
-                parsed = listOf(
-                    OcrParsedItem("품명", "카야토스트+음료세트"),
-                    OcrParsedItem("품명", "아메리카노"),
-                    OcrParsedItem("품명", "샌드위치"),
-                ),
-            )
-        }
-
-        fun createMockStr(): String {
-            return """
-                {
-                    "parsed": [
-                        {
-                            "key": "품명",
-                            "value": "카야토스트+음료세트"
-                        },
-                        {
-                            "key": "품명",
-                            "value": "아메리카노"
-                        },
-                        {
-                            "key": "품명",
-                            "value": "샌드위치"
-                        }
-                    ]
-                }
-            """.trimIndent()
-        }
-    }
-}
+)
 
 data class OcrParsedItem(
     val key: String,

--- a/data/src/main/java/com/nexters/misik/data/repository/ReviewRepositoryImpl.kt
+++ b/data/src/main/java/com/nexters/misik/data/repository/ReviewRepositoryImpl.kt
@@ -24,7 +24,7 @@ class ReviewRepositoryImpl @Inject constructor(
             hashTag = hashTags,
             reviewStyle = reviewStyle,
         )
-        remoteDataSource.generateReview(GenerateReviewRequestDto.createMock())
+        remoteDataSource.generateReview(requestDto)
     }
 
     override suspend fun getReview(id: Long): Result<ReviewEntity?> = runCatching {

--- a/data/src/main/java/com/nexters/misik/data/repository/ReviewRepositoryImpl.kt
+++ b/data/src/main/java/com/nexters/misik/data/repository/ReviewRepositoryImpl.kt
@@ -2,12 +2,12 @@ package com.nexters.misik.data.repository
 
 import com.nexters.misik.data.datasource.RemoteDataSource
 import com.nexters.misik.data.mapper.ReviewMapper.toDomain
+import com.nexters.misik.domain.ParsedEntity
 import com.nexters.misik.domain.ReviewEntity
 import com.nexters.misik.domain.ReviewRepository
 import com.nexters.misik.network.dto.request.GenerateReviewRequestDto
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.IOException
 import javax.inject.Inject
 
 class ReviewRepositoryImpl @Inject constructor(
@@ -31,10 +31,9 @@ class ReviewRepositoryImpl @Inject constructor(
         remoteDataSource.getReview(id).toDomain()
     }
 
-    override suspend fun getOcrParsedResponse(text: String): Result<String> = runCatching {
+    override suspend fun getOcrParsedResponse(text: String): Result<ParsedEntity?> = runCatching {
         withContext(Dispatchers.IO) {
-            remoteDataSource.getOcrParsedResponse(text)
-                ?: throw IOException("Failed to fetch OCR response")
+            remoteDataSource.getOcrParsedResponse(text).toDomain()
         }
     }
 }

--- a/domain/src/main/java/com/nexters/misik/domain/ParsedEntity.kt
+++ b/domain/src/main/java/com/nexters/misik/domain/ParsedEntity.kt
@@ -1,0 +1,10 @@
+package com.nexters.misik.domain
+
+data class ParsedEntity(
+    val parsed: List<ParsedOcr>,
+)
+
+data class ParsedOcr(
+    val key: String?,
+    val value: String?,
+)

--- a/domain/src/main/java/com/nexters/misik/domain/ReviewRepository.kt
+++ b/domain/src/main/java/com/nexters/misik/domain/ReviewRepository.kt
@@ -7,5 +7,5 @@ interface ReviewRepository {
     // 리뷰 조회
     suspend fun getReview(id: Long): Result<ReviewEntity?>
 
-    suspend fun getOcrParsedResponse(text: String): Result<String>
+    suspend fun getOcrParsedResponse(text: String): Result<ParsedEntity?>
 }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
@@ -101,8 +101,6 @@ fun WebViewScreen(
                 )
             }
         }
-
-
     }
 }
 

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
@@ -70,13 +70,13 @@ fun WebViewScreen(
     }
 
     Box(modifier = modifier.fillMaxSize()) {
-//        AndroidView(
-//            modifier = Modifier.fillMaxSize(),
-//            factory = { webView },
-//            update = { webView ->
-//                Timber.d("updated :${webView.hashCode()}")
-//            },
-//        )
+        AndroidView(
+            modifier = Modifier.fillMaxSize(),
+            factory = { webView },
+            update = { webView ->
+                Timber.d("updated :${webView.hashCode()}")
+            },
+        )
         when (val state = uiState) {
             is WebViewState.CopyToClipBoard -> {
                 CopyToClipboard(state.review)
@@ -94,11 +94,6 @@ fun WebViewScreen(
             }
 
             else -> {
-                Timber.d("WebViewScreen_UiState", "Loaded")
-                AndroidView(
-                    modifier = Modifier.fillMaxSize(),
-                    factory = { webView },
-                )
             }
         }
     }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
@@ -1,6 +1,10 @@
 package com.nexters.misik.webview
 
 import android.annotation.SuppressLint
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -61,18 +65,13 @@ fun WebViewScreen(
             webView.evaluateJavascript(it, null)
             Timber.d("WebViewScreen_toJS_Success", it)
         } ?: Timber.d("WebViewScreen_toJS_Failure", "js is null")
-
     }
 
-
-
     Box(modifier = modifier.fillMaxSize()) {
-        when (uiState) {
-//            WebViewState.PageLoading -> {
-//                Timber.d("WebViewScreen_UiState", "Loading")
-//                LoadingAnimation(modifier = Modifier.align(Alignment.Center))
-//            }
-
+        when (val state = uiState) {
+            is WebViewState.CopyToClipBoard -> {
+                CopyToClipboard(state.review)
+            }
 
             else -> {
                 Timber.d("WebViewScreen_UiState", "Loaded")
@@ -83,4 +82,13 @@ fun WebViewScreen(
             }
         }
     }
+}
+
+@Composable
+fun CopyToClipboard(review: String) {
+    val context = LocalContext.current
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    val clip = ClipData.newPlainText("Review", review)
+    clipboard.setPrimaryClip(clip)
+    Toast.makeText(context, "리뷰가 클립보드에 복사되었습니다.", Toast.LENGTH_SHORT).show()
 }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
@@ -5,10 +5,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
@@ -17,7 +15,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nexters.misik.preview.PreviewService
 import com.nexters.misik.webview.base.MisikWebViewFactory
 import com.nexters.misik.webview.bridge.WebInterface
-import com.nexters.misik.webview.common.LoadingAnimation
 import timber.log.Timber
 
 @SuppressLint("SetJavaScriptEnabled", "JavascriptInterface")
@@ -28,7 +25,7 @@ fun WebViewScreen(
     viewModel: WebViewViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
-    val responseJs by viewModel.responseJs.collectAsState()
+    val responseJs by viewModel.responseJs.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
     val webInterface = remember {
@@ -45,6 +42,7 @@ fun WebViewScreen(
                         viewModel.sendIntent(WebViewIntent.HandleOcrResult(it))
                     },
                 )
+
                 else -> viewModel.sendIntent(intent)
             }
         }
@@ -59,18 +57,20 @@ fun WebViewScreen(
     }
 
     LaunchedEffect(responseJs) {
-        responseJs?.let { jsResponse ->
-            Timber.d("WebViewScreen_ResponseJs", jsResponse)
-            webView.loadUrl(jsResponse)
-        }
+        responseJs?.let {
+            webView.evaluateJavascript(it, null)
+            Timber.d("WebViewScreen_toJS_receiveScan_Success", it)
+        } ?: Timber.d("WebViewScreen_toJS_receiveScan", "js is null")
     }
+
+
 
     Box(modifier = modifier.fillMaxSize()) {
         when (uiState) {
-            WebViewState.PageLoading -> {
-                Timber.d("WebViewScreen_UiState", "Loading")
-                LoadingAnimation(modifier = Modifier.align(Alignment.Center))
-            }
+//            WebViewState.PageLoading -> {
+//                Timber.d("WebViewScreen_UiState", "Loading")
+//                LoadingAnimation(modifier = Modifier.align(Alignment.Center))
+//            }
 
             else -> {
                 Timber.d("WebViewScreen_UiState", "Loaded")

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
@@ -59,8 +59,9 @@ fun WebViewScreen(
     LaunchedEffect(responseJs) {
         responseJs?.let {
             webView.evaluateJavascript(it, null)
-            Timber.d("WebViewScreen_toJS_receiveScan_Success", it)
-        } ?: Timber.d("WebViewScreen_toJS_receiveScan", "js is null")
+            Timber.d("WebViewScreen_toJS_Success", it)
+        } ?: Timber.d("WebViewScreen_toJS_Failure", "js is null")
+
     }
 
 
@@ -71,6 +72,7 @@ fun WebViewScreen(
 //                Timber.d("WebViewScreen_UiState", "Loading")
 //                LoadingAnimation(modifier = Modifier.align(Alignment.Center))
 //            }
+
 
             else -> {
                 Timber.d("WebViewScreen_UiState", "Loaded")

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
@@ -19,6 +20,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nexters.misik.preview.PreviewService
 import com.nexters.misik.webview.base.MisikWebViewFactory
 import com.nexters.misik.webview.bridge.WebInterface
+import com.nexters.misik.webview.common.LoadingAnimation
 import timber.log.Timber
 
 @SuppressLint("SetJavaScriptEnabled", "JavascriptInterface")
@@ -68,14 +70,13 @@ fun WebViewScreen(
     }
 
     Box(modifier = modifier.fillMaxSize()) {
-        AndroidView(
-            modifier = Modifier.fillMaxSize(),
-            factory = { webView },
-            update = { webView ->
-                Timber.d("updated :${webView.hashCode()}")
-            },
-        )
-
+//        AndroidView(
+//            modifier = Modifier.fillMaxSize(),
+//            factory = { webView },
+//            update = { webView ->
+//                Timber.d("updated :${webView.hashCode()}")
+//            },
+//        )
         when (val state = uiState) {
             is WebViewState.CopyToClipBoard -> {
                 CopyToClipboard(state.review)

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewState.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewState.kt
@@ -1,8 +1,11 @@
 package com.nexters.misik.webview
 
+import com.nexters.misik.domain.ParsedEntity
+
 sealed class WebViewState {
     data object PageLoading : WebViewState()
     data object PageLoaded : WebViewState()
+    data class ParseOcrText(val ocrText: ParsedEntity) : WebViewState()
     data class GenerateReview(val id: Long) : WebViewState()
     data class CompleteReview(val review: String) : WebViewState()
     data class ResponseJS(val response: String) : WebViewState()

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewState.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewState.kt
@@ -1,13 +1,13 @@
 package com.nexters.misik.webview
 
 import com.nexters.misik.domain.ParsedEntity
-
 sealed class WebViewState {
     data object PageLoading : WebViewState()
     data object PageLoaded : WebViewState()
     data class ParseOcrText(val ocrText: ParsedEntity) : WebViewState()
     data class GenerateReview(val id: Long) : WebViewState()
     data class CompleteReview(val review: String) : WebViewState()
+    data class CopyToClipBoard(val review: String) : WebViewState()
     data class ResponseJS(val response: String) : WebViewState()
     data class Error(val message: String) : WebViewState()
 }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
@@ -51,8 +51,8 @@ class WebViewViewModel @Inject constructor(
         }
     }
 
-    private fun copyToClipboard(review: String) {
-        // TODO
+    fun copyToClipboard(review: String) {
+        _state.value = WebViewState.CopyToClipBoard(review)
     }
 
     fun onEvent(event: WebViewEvent) {
@@ -141,6 +141,7 @@ class WebViewViewModel @Inject constructor(
                 }
         }
     }
+
     private fun getReview(id: Long) {
         viewModelScope.launch {
             reviewRepository.getReview(id)
@@ -150,7 +151,8 @@ class WebViewViewModel @Inject constructor(
                     val jsonResponse = JSONObject()
                     jsonResponse.put("result", reviewText)
 
-                    _responseJs.value = makeResponse("receiveGeneratedReview", jsonResponse.toString())
+                    _responseJs.value =
+                        makeResponse("receiveGeneratedReview", jsonResponse.toString())
 
                     Timber.d("getReview_Success", " ${data.isSuccess} $reviewText ${data.id}")
                 }
@@ -159,5 +161,4 @@ class WebViewViewModel @Inject constructor(
                 }
         }
     }
-
 }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
@@ -141,14 +141,17 @@ class WebViewViewModel @Inject constructor(
                 }
         }
     }
-
     private fun getReview(id: Long) {
         viewModelScope.launch {
             reviewRepository.getReview(id)
                 .onSuccess { data ->
                     val reviewText = data?.review ?: return@launch
                     _state.value = WebViewState.CompleteReview(reviewText)
-                    // TODO : receiveGenerateReview 웹으로 보내기
+                    val jsonResponse = JSONObject()
+                    jsonResponse.put("result", reviewText)
+
+                    _responseJs.value = makeResponse("receiveGeneratedReview", jsonResponse.toString())
+
                     Timber.d("getReview_Success", " ${data.isSuccess} $reviewText ${data.id}")
                 }
                 .onFailure { exception ->
@@ -156,4 +159,5 @@ class WebViewViewModel @Inject constructor(
                 }
         }
     }
+
 }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/bridge/WebInterface.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/bridge/WebInterface.kt
@@ -7,6 +7,7 @@ import com.nexters.misik.webview.WebViewIntent
 import com.nexters.misik.webview.bridge.dto.request.CopyRequest
 import com.nexters.misik.webview.bridge.dto.request.CreateReviewRequest
 import com.nexters.misik.webview.bridge.dto.request.toIntent
+import org.json.JSONObject
 import timber.log.Timber
 
 class WebInterface(
@@ -28,8 +29,14 @@ class WebInterface(
 
     @JavascriptInterface
     fun share(content: String) {
-        Timber.i("share: $content")
-        eventCallback(WebViewIntent.Share(content))
+        try {
+            val json = JSONObject(content)
+            val reviewText = json.optString("review")
+            val intent = WebViewIntent.Copy(reviewText)
+
+            eventCallback(intent)
+        } catch (e: Exception) {
+        }
     }
 
     @JavascriptInterface
@@ -40,15 +47,13 @@ class WebInterface(
             val intent = WebViewIntent.CreateReview(
                 ocrText = request.ocrText,
                 hashTags = request.hashTag,
-                reviewStyle = request.reviewStyle
+                reviewStyle = request.reviewStyle,
             )
 
             eventCallback(intent)
         } catch (e: JsonSyntaxException) {
         }
     }
-
-
 
     @JavascriptInterface
     fun copy(json: String) {

--- a/feature/webview/src/main/java/com/nexters/misik/webview/bridge/WebInterface.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/bridge/WebInterface.kt
@@ -2,6 +2,7 @@ package com.nexters.misik.webview.bridge
 
 import android.webkit.JavascriptInterface
 import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
 import com.nexters.misik.webview.WebViewIntent
 import com.nexters.misik.webview.bridge.dto.request.CopyRequest
 import com.nexters.misik.webview.bridge.dto.request.CreateReviewRequest
@@ -33,10 +34,21 @@ class WebInterface(
 
     @JavascriptInterface
     fun createReview(json: String) {
-        Timber.i("createReview: $json")
-        val request = gson.fromJson(json, CreateReviewRequest::class.java)
-        eventCallback(request.toIntent())
+        try {
+            val request = gson.fromJson(json, CreateReviewRequest::class.java)
+
+            val intent = WebViewIntent.CreateReview(
+                ocrText = request.ocrText,
+                hashTags = request.hashTag,
+                reviewStyle = request.reviewStyle
+            )
+
+            eventCallback(intent)
+        } catch (e: JsonSyntaxException) {
+        }
     }
+
+
 
     @JavascriptInterface
     fun copy(json: String) {

--- a/network/src/main/java/com/nexters/misik/network/NetworkModule.kt
+++ b/network/src/main/java/com/nexters/misik/network/NetworkModule.kt
@@ -13,6 +13,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Converter
 import retrofit2.Retrofit
+import java.util.concurrent.TimeUnit
 import javax.inject.Qualifier
 import javax.inject.Singleton
 
@@ -73,6 +74,9 @@ object NetworkModule {
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(loggingInterceptor)
         .addInterceptor(authInterceptor)
+        .connectTimeout(300, TimeUnit.SECONDS)
+        .readTimeout(300, TimeUnit.SECONDS)
+        .writeTimeout(300, TimeUnit.SECONDS)
         .build()
 
     @Singleton

--- a/network/src/main/java/com/nexters/misik/network/dto/request/GenerateReviewRequestDto.kt
+++ b/network/src/main/java/com/nexters/misik/network/dto/request/GenerateReviewRequestDto.kt
@@ -11,14 +11,4 @@ data class GenerateReviewRequestDto(
     val hashTag: List<String>?,
     @SerialName("reviewStyle")
     val reviewStyle: String?,
-) {
-    companion object {
-        fun createMock(): GenerateReviewRequestDto {
-            return GenerateReviewRequestDto(
-                ocrText = "청담커피•앤•토스트 전화번호: 02-554-2458•주소: 서울특별시 강남구 • 테헤란로 313•지하 1층• 2024-07-29 NO: 2-267 •품명 • 단가 수량 카야토스트 음료세트 3,000 admin 금액 6.5 100% • 리얼 토마토 생과일주스 (3500) 소계 1품목 1건 6,500",
-                hashTag = listOf("특별한 메뉴가 있어요"),
-                reviewStyle = "CUTE",
-            )
-        }
-    }
-}
+)

--- a/network/src/main/java/com/nexters/misik/network/service/ReviewService.kt
+++ b/network/src/main/java/com/nexters/misik/network/service/ReviewService.kt
@@ -3,8 +3,7 @@ package com.nexters.misik.network.service
 import com.nexters.misik.network.dto.request.GenerateReviewRequestDto
 import com.nexters.misik.network.dto.request.OcrParseRequestDto
 import com.nexters.misik.network.dto.response.GetReviewResponseDto
-import okhttp3.ResponseBody
-import retrofit2.Response
+import com.nexters.misik.network.dto.response.OcrParsedResponseDto
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -27,5 +26,5 @@ interface ReviewService {
     @POST("reviews/ocr-parsing")
     suspend fun getOcrParsedResponse(
         @Body request: OcrParseRequestDto,
-    ): Response<ResponseBody>
+    ): OcrParsedResponseDto
 }


### PR DESCRIPTION
- closes #25 

## Description

- web -> client 인터페이스 구현
  - copy
  - createReview
- client -> web 데이터 전달 구현
  - receiveScanResult
  - receiveGeneratedReview
- 파싱 API가 시간이 좀 걸리길래 일단 타임아웃 5분으로 세팅해둠


## To Reviewers
- 기존에 OCR Parsing에서 안넘어가던 이유는 API 응답 형태 & 웹한테 보내는 데이터 형태가 잘못되어있더라구요, 그래서 해당 형태 맞추도록 수정했습니다. 해결한 김에 receiveScanResult까지 이어서 구현하고 나머지다했어요 ~ ! 필요한거있으면 일단 만들면서 구현해가지고 테스터 배포 후에 리팩토링할게요 

- 그리고 #23 PR 머지했는데, androidview 코드가 추가되면서 앱이 터지길래 일단 그부분만 주석처리해두었습니다. 이거 관련해서 같이 보면좋을것같아요 ~ 
