### PR TITLE
[refactor] safe area 대응, 서버 오류 시 실패 웹에게 전달 

### DIFF
--- a/feature/webview/src/main/java/com/nexters/misik/webview/MainActivity.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/MainActivity.kt
@@ -39,7 +39,7 @@ class MainActivity : ComponentActivity() {
             Scaffold(
                 modifier = Modifier
                     .fillMaxSize()
-                    .safeDrawingPadding()
+                    .safeDrawingPadding(),
             ) { innerPadding ->
                 WebViewScreen(
                     previewService,
@@ -49,6 +49,5 @@ class MainActivity : ComponentActivity() {
                 )
             }
         }
-
     }
 }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/MainActivity.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
 import androidx.multidex.BuildConfig
@@ -35,12 +36,19 @@ class MainActivity : ComponentActivity() {
         previewService.init(this)
 
         setContent {
-            Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+            Scaffold(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .safeDrawingPadding()
+            ) { innerPadding ->
                 WebViewScreen(
                     previewService,
-                    modifier = Modifier.padding(innerPadding),
+                    modifier = Modifier
+                        .padding(innerPadding)
+                        .safeDrawingPadding(),
                 )
             }
         }
+
     }
 }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
@@ -92,6 +92,7 @@ class WebViewViewModel @Inject constructor(
                 }
                 .onFailure { exception ->
                     _state.value = WebViewState.PageLoaded
+                    _responseJs.value = makeResponse("receiveScanResult", "")
                     Timber.d("parsingOcr_Failure", exception.message)
                 }
         }
@@ -139,11 +140,13 @@ class WebViewViewModel @Inject constructor(
                     jsonResponse.put("result", reviewText)
 
                     _responseJs.value =
-                        makeResponse("receiveGeneratedReview", jsonResponse.toString())
+                        makeResponse("receiveGeneratedReview", "")
 
                     Timber.d("getReview_Success", " ${data.isSuccess} $reviewText ${data.id}")
                 }
                 .onFailure { exception ->
+                    _responseJs.value =
+                        makeResponse("receiveGeneratedReview", "")
                     Timber.d("getReview_Failure", exception.message)
                 }
         }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
@@ -84,7 +84,7 @@ class WebViewViewModel @Inject constructor(
                     if (data != null) {
                         val jsonResponse = convertToJson(data)
                         _state.value = WebViewState.ParseOcrText(data)
-                        _responseJs.value = makeResponse("receiveScanResult", jsonResponse)
+                        _responseJs.value = makeResponse("receiveScanResult", SERVER_FAILURE_MSG)
 
                         Timber.d("parsingOcr_Success", jsonResponse)
                     }
@@ -140,7 +140,7 @@ class WebViewViewModel @Inject constructor(
                     jsonResponse.put("result", reviewText)
 
                     _responseJs.value =
-                        makeResponse("receiveGeneratedReview", jsonResponse.toString())
+                        makeResponse("receiveGeneratedReview", SERVER_FAILURE_MSG)
 
                     Timber.d("getReview_Success", " ${data.isSuccess} $reviewText ${data.id}")
                 }
@@ -152,7 +152,7 @@ class WebViewViewModel @Inject constructor(
         }
     }
 
-    companion object{
+    companion object {
         const val SERVER_FAILURE_MSG = "error"
     }
 }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
@@ -84,7 +84,7 @@ class WebViewViewModel @Inject constructor(
                     if (data != null) {
                         val jsonResponse = convertToJson(data)
                         _state.value = WebViewState.ParseOcrText(data)
-                        _responseJs.value = makeResponse("receiveScanResult", SERVER_FAILURE_MSG)
+                        _responseJs.value = makeResponse("receiveScanResult", jsonResponse)
 
                         Timber.d("parsingOcr_Success", jsonResponse)
                     }
@@ -140,13 +140,15 @@ class WebViewViewModel @Inject constructor(
                     jsonResponse.put("result", reviewText)
 
                     _responseJs.value =
-                        makeResponse("receiveGeneratedReview", SERVER_FAILURE_MSG)
+                        makeResponse("receiveGeneratedReview", jsonResponse.toString())
 
                     Timber.d("getReview_Success", " ${data.isSuccess} $reviewText ${data.id}")
                 }
                 .onFailure { exception ->
+                    val jsonResponse = JSONObject()
+                    jsonResponse.put("result", SERVER_FAILURE_MSG)
                     _responseJs.value =
-                        makeResponse("receiveGeneratedReview", SERVER_FAILURE_MSG)
+                        makeResponse("receiveGeneratedReview", jsonResponse.toString())
                     Timber.d("getReview_Failure", exception.message)
                 }
         }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
@@ -92,7 +92,6 @@ class WebViewViewModel @Inject constructor(
                 }
                 .onFailure { exception ->
                     _state.value = WebViewState.PageLoaded
-                    _responseJs.value = makeResponse("receiveScanResult", "")
                     Timber.d("parsingOcr_Failure", exception.message)
                 }
         }
@@ -140,13 +139,11 @@ class WebViewViewModel @Inject constructor(
                     jsonResponse.put("result", reviewText)
 
                     _responseJs.value =
-                        makeResponse("receiveGeneratedReview", "")
+                        makeResponse("receiveGeneratedReview", jsonResponse.toString())
 
                     Timber.d("getReview_Success", " ${data.isSuccess} $reviewText ${data.id}")
                 }
                 .onFailure { exception ->
-                    _responseJs.value =
-                        makeResponse("receiveGeneratedReview", "")
                     Timber.d("getReview_Failure", exception.message)
                 }
         }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
@@ -92,6 +92,7 @@ class WebViewViewModel @Inject constructor(
                 }
                 .onFailure { exception ->
                     _state.value = WebViewState.PageLoaded
+                    _responseJs.value = makeResponse("receiveScanResult", SERVER_FAILURE_MSG)
                     Timber.d("parsingOcr_Failure", exception.message)
                 }
         }
@@ -144,8 +145,14 @@ class WebViewViewModel @Inject constructor(
                     Timber.d("getReview_Success", " ${data.isSuccess} $reviewText ${data.id}")
                 }
                 .onFailure { exception ->
+                    _responseJs.value =
+                        makeResponse("receiveGeneratedReview", SERVER_FAILURE_MSG)
                     Timber.d("getReview_Failure", exception.message)
                 }
         }
+    }
+
+    companion object{
+        const val SERVER_FAILURE_MSG = "error"
     }
 }


### PR DESCRIPTION
- closed #34 

## Description

- 서버 요청 실패시, 웹에게 에러 전달 (receiveScanResult, recevieGeneratedReview)
- safeArea 대응 : safeDrawingPadding 적용

