### PR TITLE
[feat] 강제업데이트 구현, 공유하기 브릿지 수정, 키보드 높이 웹에게 전달

### DIFF
--- a/build-logic/convention/src/main/java/com/nexters/misik/convention/BuildConfig.kt
+++ b/build-logic/convention/src/main/java/com/nexters/misik/convention/BuildConfig.kt
@@ -2,6 +2,8 @@ package com.nexters.misik.convention
 
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+import com.nexters.misik.convention.extension.getVersion
+import com.nexters.misik.convention.extension.libs
 import org.gradle.api.Project
 
 internal fun Project.configureBuildConfig(
@@ -9,10 +11,27 @@ internal fun Project.configureBuildConfig(
 ) {
     commonExtension.apply {
         defaultConfig {
+            // BASE_URL
             buildConfigField(
                 "String",
                 "BASE_URL",
                 gradleLocalProperties(rootDir, providers).getProperty("base.url"),
+            )
+
+            // VERSION_CODE, VERSION_NAME
+            val versionCode = libs.getVersion("versionCode").requiredVersion.toInt()
+            val versionName = libs.getVersion("versionName").requiredVersion
+
+            buildConfigField(
+                "int",
+                "VERSION_CODE",
+                versionCode.toString(),
+            )
+
+            buildConfigField(
+                "String",
+                "VERSION_NAME",
+                "\"$versionName\"",
             )
         }
 

--- a/data/src/main/java/com/nexters/misik/data/datasource/RemoteDataSource.kt
+++ b/data/src/main/java/com/nexters/misik/data/datasource/RemoteDataSource.kt
@@ -3,6 +3,7 @@ package com.nexters.misik.data.datasource
 import com.nexters.misik.data.mapper.ReviewMapper.toModel
 import com.nexters.misik.data.model.OcrParsedResponse
 import com.nexters.misik.data.model.Review
+import com.nexters.misik.data.model.VersionUpdateUrl
 import com.nexters.misik.network.dto.request.GenerateReviewRequestDto
 import com.nexters.misik.network.dto.request.OcrParseRequestDto
 import com.nexters.misik.network.service.ReviewService
@@ -19,4 +20,10 @@ class RemoteDataSource @Inject constructor(
 
     suspend fun getOcrParsedResponse(text: String): OcrParsedResponse =
         reviewService.getOcrParsedResponse(OcrParseRequestDto(text)).toModel()
+
+    suspend fun getVersionUpdateStatus(
+        appVersion: String,
+        appPlatform: String,
+    ): VersionUpdateUrl =
+        reviewService.getUpdateStatus(appVersion = appVersion, appPlatform = appPlatform).toModel()
 }

--- a/data/src/main/java/com/nexters/misik/data/mapper/ReviewMapper.kt
+++ b/data/src/main/java/com/nexters/misik/data/mapper/ReviewMapper.kt
@@ -59,12 +59,10 @@ object ReviewMapper {
         )
     }
 
-
     fun VersionUpdateUrl.toDomain(): UpdateUrl {
         return UpdateUrl(
             statusCode = this.statusCode,
             url = this.url,
         )
     }
-
 }

--- a/data/src/main/java/com/nexters/misik/data/mapper/ReviewMapper.kt
+++ b/data/src/main/java/com/nexters/misik/data/mapper/ReviewMapper.kt
@@ -3,11 +3,15 @@ package com.nexters.misik.data.mapper
 import com.nexters.misik.data.model.OcrParsedItem
 import com.nexters.misik.data.model.OcrParsedResponse
 import com.nexters.misik.data.model.Review
+import com.nexters.misik.data.model.VersionUpdateUrl
 import com.nexters.misik.domain.ParsedEntity
 import com.nexters.misik.domain.ParsedOcr
 import com.nexters.misik.domain.ReviewEntity
+import com.nexters.misik.domain.UpdateUrl
 import com.nexters.misik.network.dto.response.GetReviewResponseDto
+import com.nexters.misik.network.dto.response.GetVersionUpdateDto
 import com.nexters.misik.network.dto.response.OcrParsedResponseDto
+import retrofit2.Response
 
 object ReviewMapper {
     fun GetReviewResponseDto.toModel(): Review {
@@ -29,6 +33,13 @@ object ReviewMapper {
         )
     }
 
+    fun Response<GetVersionUpdateDto>.toModel(): VersionUpdateUrl {
+        return VersionUpdateUrl(
+            statusCode = this.code(),
+            url = this.body()?.url ?: "",
+        )
+    }
+
     fun Review.toDomain(): ReviewEntity {
         return ReviewEntity(
             id = this.id,
@@ -47,4 +58,13 @@ object ReviewMapper {
             },
         )
     }
+
+
+    fun VersionUpdateUrl.toDomain(): UpdateUrl {
+        return UpdateUrl(
+            statusCode = this.statusCode,
+            url = this.url,
+        )
+    }
+
 }

--- a/data/src/main/java/com/nexters/misik/data/model/VersionUpdateUrl.kt
+++ b/data/src/main/java/com/nexters/misik/data/model/VersionUpdateUrl.kt
@@ -1,0 +1,6 @@
+package com.nexters.misik.data.model
+
+data class VersionUpdateUrl (
+    val statusCode: Int,
+    val url: String?,
+)

--- a/data/src/main/java/com/nexters/misik/data/model/VersionUpdateUrl.kt
+++ b/data/src/main/java/com/nexters/misik/data/model/VersionUpdateUrl.kt
@@ -1,6 +1,6 @@
 package com.nexters.misik.data.model
 
-data class VersionUpdateUrl (
+data class VersionUpdateUrl(
     val statusCode: Int,
     val url: String?,
 )

--- a/data/src/main/java/com/nexters/misik/data/repository/ReviewRepositoryImpl.kt
+++ b/data/src/main/java/com/nexters/misik/data/repository/ReviewRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.nexters.misik.data.mapper.ReviewMapper.toDomain
 import com.nexters.misik.domain.ParsedEntity
 import com.nexters.misik.domain.ReviewEntity
 import com.nexters.misik.domain.ReviewRepository
+import com.nexters.misik.domain.UpdateUrl
 import com.nexters.misik.network.dto.request.GenerateReviewRequestDto
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -35,5 +36,12 @@ class ReviewRepositoryImpl @Inject constructor(
         withContext(Dispatchers.IO) {
             remoteDataSource.getOcrParsedResponse(text).toDomain()
         }
+    }
+
+    override suspend fun getVersionUpdateStatus(
+        appVersion: String,
+        appPlatform: String,
+    ): Result<UpdateUrl?> = runCatching {
+        remoteDataSource.getVersionUpdateStatus(appVersion, appPlatform).toDomain()
     }
 }

--- a/domain/src/main/java/com/nexters/misik/domain/ReviewRepository.kt
+++ b/domain/src/main/java/com/nexters/misik/domain/ReviewRepository.kt
@@ -2,10 +2,16 @@ package com.nexters.misik.domain
 
 interface ReviewRepository {
     // 리뷰 생성
-    suspend fun generateReview(ocrText: String, hashTags: List<String>, reviewStyle: String): Result<Long?>
+    suspend fun generateReview(
+        ocrText: String,
+        hashTags: List<String>,
+        reviewStyle: String,
+    ): Result<Long?>
 
     // 리뷰 조회
     suspend fun getReview(id: Long): Result<ReviewEntity?>
 
     suspend fun getOcrParsedResponse(text: String): Result<ParsedEntity?>
+
+    suspend fun getVersionUpdateStatus(appVersion: String, appPlatform: String): Result<UpdateUrl?>
 }

--- a/domain/src/main/java/com/nexters/misik/domain/UpdateUrl.kt
+++ b/domain/src/main/java/com/nexters/misik/domain/UpdateUrl.kt
@@ -1,0 +1,6 @@
+package com.nexters.misik.domain
+
+data class UpdateUrl (
+    val statusCode: Int?,
+    val url: String?
+)

--- a/domain/src/main/java/com/nexters/misik/domain/UpdateUrl.kt
+++ b/domain/src/main/java/com/nexters/misik/domain/UpdateUrl.kt
@@ -1,6 +1,6 @@
 package com.nexters.misik.domain
 
-data class UpdateUrl (
+data class UpdateUrl(
     val statusCode: Int?,
-    val url: String?
+    val url: String?,
 )

--- a/feature/webview/build.gradle.kts
+++ b/feature/webview/build.gradle.kts
@@ -2,10 +2,12 @@ plugins {
     alias(libs.plugins.misik.android.library)
     alias(libs.plugins.misik.feature)
     alias(libs.plugins.misik.android.hilt)
+    alias(libs.plugins.misik.plugin.build.config)
 }
 
 android {
     namespace = "com.nexters.misik.feature.webview"
+
 }
 
 dependencies {

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewIntent.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewIntent.kt
@@ -3,7 +3,7 @@ package com.nexters.misik.webview
 sealed interface WebViewIntent {
     data object OpenCamera : WebViewIntent
     data object OpenGallery : WebViewIntent
-    data object Share : WebViewIntent
+    data class Share(val shareText: String) : WebViewIntent
     data class CreateReview(
         val ocrText: String,
         val hashTags: List<String>,

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
@@ -4,26 +4,35 @@ import android.annotation.SuppressLint
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.os.Build
+import android.view.View
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.view.WindowInsetsCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nexters.misik.preview.PreviewService
 import com.nexters.misik.webview.base.MisikWebViewFactory
 import com.nexters.misik.webview.bridge.WebInterface
 import com.nexters.misik.webview.common.LoadingAnimation
+import com.nexters.misik.webview.util.JsResponseUtil.makeKeyboardHeightResponse
 import com.nexters.misik.webview.util.ShareUtil
 import timber.log.Timber
 
+@RequiresApi(Build.VERSION_CODES.R)
 @SuppressLint("SetJavaScriptEnabled", "JavascriptInterface")
 @Composable
 fun WebViewScreen(
@@ -34,6 +43,9 @@ fun WebViewScreen(
     val uiState by viewModel.state.collectAsStateWithLifecycle()
     val responseJs by viewModel.responseJs.collectAsStateWithLifecycle()
     val context = LocalContext.current
+
+    val view = LocalView.current
+    val keyboardHeight by viewModel.keyboardHeight.collectAsState()
 
     val webInterface = remember {
         WebInterface { intent ->
@@ -51,7 +63,7 @@ fun WebViewScreen(
                 )
 
                 is WebViewIntent.Share -> {
-                    ShareUtil.shareApp(context)
+                    ShareUtil.shareApp(context, intent.shareText)
                 }
 
                 else -> viewModel.sendIntent(intent)
@@ -68,6 +80,7 @@ fun WebViewScreen(
             is WebViewState.CheckIsUpdateRequired -> {
                 state.url
             }
+
             else -> {
                 ""
             }
@@ -86,6 +99,26 @@ fun WebViewScreen(
         if (initializedUrl.isNotEmpty()) {
             webView.loadUrl(initializedUrl)
             Timber.d("WebViewScreen_LoadingUrl: $initializedUrl")
+        }
+    }
+
+    DisposableEffect(view) {
+        val listener = View.OnApplyWindowInsetsListener { v, insets ->
+            val ime = insets.getInsets(WindowInsetsCompat.Type.ime()) // 키보드 높이 가져옴
+            viewModel.updateKeyboardHeight(ime.bottom) // 뷰모델에 업데이트
+            insets // 원래의 insets 반환
+        }
+        view.setOnApplyWindowInsetsListener(listener)
+        onDispose { view.setOnApplyWindowInsetsListener(null) }
+    }
+
+    // 키보드 높이 변화 시 웹에 전달
+    LaunchedEffect(keyboardHeight) {
+        if (keyboardHeight > 0) { // 키보드가 올라왔을 때만 전달
+            val jsCode =
+                makeKeyboardHeightResponse("receiveKeyboardHeight", keyboardHeight.toString())
+            webView.evaluateJavascript(jsCode, null)
+            Timber.d("WebViewScreen_sendKeyboardHeight", jsCode)
         }
     }
 

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
@@ -6,7 +6,6 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.os.Build
 import android.view.View
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -32,7 +31,6 @@ import com.nexters.misik.webview.util.JsResponseUtil.makeKeyboardHeightResponse
 import com.nexters.misik.webview.util.ShareUtil
 import timber.log.Timber
 
-@RequiresApi(Build.VERSION_CODES.R)
 @SuppressLint("SetJavaScriptEnabled", "JavascriptInterface")
 @Composable
 fun WebViewScreen(
@@ -104,11 +102,19 @@ fun WebViewScreen(
 
     DisposableEffect(view) {
         val listener = View.OnApplyWindowInsetsListener { v, insets ->
-            val ime = insets.getInsets(WindowInsetsCompat.Type.ime()) // 키보드 높이 가져옴
-            viewModel.updateKeyboardHeight(ime.bottom) // 뷰모델에 업데이트
-            insets // 원래의 insets 반환
+            val imeBottom = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+            } else {
+                WindowInsetsCompat.toWindowInsetsCompat(insets).systemWindowInsetBottom
+            }
+
+            viewModel.updateKeyboardHeight(imeBottom)
+
+            insets
         }
+
         view.setOnApplyWindowInsetsListener(listener)
+
         onDispose { view.setOnApplyWindowInsetsListener(null) }
     }
 

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
@@ -40,37 +40,24 @@ fun WebViewScreen(
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
     val responseJs by viewModel.responseJs.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-
-    val view = LocalView.current
     val keyboardHeight by viewModel.keyboardHeight.collectAsState()
+    val context = LocalContext.current
 
     val webInterface = remember {
         WebInterface { intent ->
             when (intent) {
-                is WebViewIntent.OpenCamera -> previewService.openCamera(
-                    {
-                        viewModel.sendIntent(WebViewIntent.HandleOcrResult(it))
-                    },
-                )
-
-                is WebViewIntent.OpenGallery -> previewService.openGallery(
-                    {
-                        viewModel.sendIntent(WebViewIntent.HandleOcrResult(it))
-                    },
-                )
-
-                is WebViewIntent.Share -> {
-                    ShareUtil.shareApp(context, intent.shareText)
+                is WebViewIntent.OpenCamera -> previewService.openCamera {
+                    viewModel.sendIntent(WebViewIntent.HandleOcrResult(it))
                 }
 
+                is WebViewIntent.OpenGallery -> previewService.openGallery {
+                    viewModel.sendIntent(WebViewIntent.HandleOcrResult(it))
+                }
+
+                is WebViewIntent.Share -> ShareUtil.shareApp(context, intent.shareText)
                 else -> viewModel.sendIntent(intent)
             }
         }
-    }
-
-    LaunchedEffect(Unit) {
-        viewModel.getVersionUpdateStatus()
     }
 
     val initializedUrl by rememberUpdatedState(
@@ -93,6 +80,8 @@ fun WebViewScreen(
         )
     }
 
+    LaunchedEffect(Unit) { viewModel.getVersionUpdateStatus() }
+
     LaunchedEffect(initializedUrl) {
         if (initializedUrl.isNotEmpty()) {
             webView.loadUrl(initializedUrl)
@@ -100,68 +89,61 @@ fun WebViewScreen(
         }
     }
 
-    DisposableEffect(view) {
-        val listener = View.OnApplyWindowInsetsListener { v, insets ->
-            val imeBottom = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
-            } else {
-                WindowInsetsCompat.toWindowInsetsCompat(insets).systemWindowInsetBottom
-            }
-
-            viewModel.updateKeyboardHeight(imeBottom)
-
-            insets
-        }
-
-        view.setOnApplyWindowInsetsListener(listener)
-
-        onDispose { view.setOnApplyWindowInsetsListener(null) }
-    }
-
-    // 키보드 높이 변화 시 웹에 전달
-    LaunchedEffect(keyboardHeight) {
-        if (keyboardHeight > 0) { // 키보드가 올라왔을 때만 전달
-            val jsCode =
-                makeKeyboardHeightResponse("receiveKeyboardHeight", keyboardHeight.toString())
-            webView.evaluateJavascript(jsCode, null)
-            Timber.d("WebViewScreen_sendKeyboardHeight", jsCode)
-        }
-    }
-
-    LaunchedEffect(responseJs) {
-        responseJs?.let {
-            webView.evaluateJavascript(it, null)
-            Timber.d("WebViewScreen_toJS_Success", it)
-        } ?: Timber.d("WebViewScreen_toJS_Failure", "js is null")
-    }
+    KeyboardInsetsListener { imeBottom -> viewModel.updateKeyboardHeight(imeBottom) }
+    SendKeyboardHeightToJS(keyboardHeight, webView)
+    EvaluateResponseJs(responseJs, webView)
 
     Box(modifier = modifier.fillMaxSize()) {
         AndroidView(
             modifier = Modifier.fillMaxSize(),
             factory = { webView },
-            update = { webView ->
-                Timber.d("updated :${webView.hashCode()}")
-            },
+            update = { Timber.d("updated :${it.hashCode()}") },
         )
-        when (val state = uiState) {
-            is WebViewState.CopyToClipBoard -> {
-                CopyToClipboard(state.review)
-            }
-
-            is WebViewState.PageLoading -> {
-                Timber.d("WebViewScreen_UiState", "Loading")
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .align(Alignment.Center), // 오버레이처럼 위에 띄움
-                ) {
-                    LoadingAnimation(modifier = Modifier.align(Alignment.Center))
-                }
-            }
-
-            else -> {
-            }
+        when (uiState) {
+            is WebViewState.CopyToClipBoard -> CopyToClipboard((uiState as WebViewState.CopyToClipBoard).review)
+            is WebViewState.PageLoading -> LoadingOverlay()
+            else -> {}
         }
+    }
+}
+
+@Composable
+fun KeyboardInsetsListener(onKeyboardHeightChanged: (Int) -> Unit) {
+    val view = LocalView.current
+    DisposableEffect(view) {
+        val listener = View.OnApplyWindowInsetsListener { _, insets ->
+            val imeBottom = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+            } else {
+                WindowInsetsCompat.toWindowInsetsCompat(insets).systemWindowInsetBottom
+            }
+            onKeyboardHeightChanged(imeBottom)
+            insets
+        }
+        view.setOnApplyWindowInsetsListener(listener)
+        onDispose { view.setOnApplyWindowInsetsListener(null) }
+    }
+}
+
+@Composable
+fun SendKeyboardHeightToJS(keyboardHeight: Int, webView: android.webkit.WebView) {
+    LaunchedEffect(keyboardHeight) {
+        if (keyboardHeight > 0) {
+            val jsCode =
+                makeKeyboardHeightResponse("receiveKeyboardHeight", keyboardHeight.toString())
+            webView.evaluateJavascript(jsCode, null)
+            Timber.d("WebViewScreen_sendKeyboardHeight: $jsCode")
+        }
+    }
+}
+
+@Composable
+fun EvaluateResponseJs(responseJs: String?, webView: android.webkit.WebView) {
+    LaunchedEffect(responseJs) {
+        responseJs?.let {
+            webView.evaluateJavascript(it, null)
+            Timber.d("WebViewScreen_toJS_Success: $it")
+        } ?: Timber.d("WebViewScreen_toJS_Failure: js is null")
     }
 }
 
@@ -169,6 +151,15 @@ fun WebViewScreen(
 fun CopyToClipboard(review: String) {
     val context = LocalContext.current
     val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-    val clip = ClipData.newPlainText("Review", review)
-    clipboard.setPrimaryClip(clip)
+    clipboard.setPrimaryClip(ClipData.newPlainText("Review", review))
+}
+
+@Composable
+fun LoadingOverlay() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        LoadingAnimation()
+    }
 }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -58,12 +59,34 @@ fun WebViewScreen(
         }
     }
 
+    LaunchedEffect(Unit) {
+        viewModel.getVersionUpdateStatus()
+    }
+
+    val initializedUrl by rememberUpdatedState(
+        when (val state = uiState) {
+            is WebViewState.CheckIsUpdateRequired -> {
+                state.url
+            }
+            else -> {
+                ""
+            }
+        },
+    )
+
     val webView = remember {
         MisikWebViewFactory.create(
             context = context,
             webInterface = webInterface,
             onEvent = { event -> viewModel.onEvent(event) },
         )
+    }
+
+    LaunchedEffect(initializedUrl) {
+        if (initializedUrl.isNotEmpty()) {
+            webView.loadUrl(initializedUrl)
+            Timber.d("WebViewScreen_LoadingUrl: $initializedUrl")
+        }
     }
 
     LaunchedEffect(responseJs) {

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewState.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewState.kt
@@ -4,6 +4,7 @@ import com.nexters.misik.domain.ParsedEntity
 sealed class WebViewState {
     data object PageLoading : WebViewState()
     data object PageLoaded : WebViewState()
+    data class CheckIsUpdateRequired(val url: String) : WebViewState()
     data class ParseOcrText(val ocrText: ParsedEntity) : WebViewState()
     data class GenerateReview(val id: Long) : WebViewState()
     data class CompleteReview(val review: String) : WebViewState()

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
@@ -76,6 +76,37 @@ class WebViewViewModel @Inject constructor(
         }
     }
 
+    fun getVersionUpdateStatus() {
+        viewModelScope.launch {
+            _state.value = WebViewState.PageLoading
+            reviewRepository.getVersionUpdateStatus(appVersion = "1.0.0", appPlatform = "ANDROID")
+                .onSuccess { data ->
+                    if (data != null) {
+                        val url = data.url
+                        when (data.statusCode) {
+                            200 -> {
+                                if (url != null) {
+                                    _state.value = WebViewState.CheckIsUpdateRequired(url)
+                                }
+                            }
+
+                            426 -> {
+                                if (url != null) {
+                                    _state.value = WebViewState.CheckIsUpdateRequired(url)
+                                }
+                            }
+                        }
+
+                        Timber.d("getVersionUpdateStatus_Success", url)
+                    }
+                }
+                .onFailure { exception ->
+                    _state.value = WebViewState.PageLoading
+                    Timber.d("getVersionUpdateStatus_Failure", exception.message)
+                }
+        }
+    }
+
     private fun parsingOcr(ocrText: String) {
         viewModelScope.launch {
             _state.value = WebViewState.PageLoading

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
@@ -105,7 +105,6 @@ class WebViewViewModel @Inject constructor(
         }
     }
 
-    private fun parsingOcr(ocrText: String) {
     private fun responseOcrParsed(ocrText: String?) {
         viewModelScope.launch {
             ocrText?.let {
@@ -149,7 +148,8 @@ class WebViewViewModel @Inject constructor(
                     Timber.d("getReview_Success", " ${data.isSuccess} $reviewText ${data.id}")
                 }
                 .onFailure { exception ->
-                    _responseJs.value = JsResponseUtil.makeFailureResponse("receiveGeneratedReview")
+                    _responseJs.value =
+                        JsResponseUtil.makeFailureResponse("receiveGeneratedReview")
                     Timber.d("getReview_Failure", exception.message)
                 }
         }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
@@ -3,6 +3,7 @@ package com.nexters.misik.webview
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nexters.misik.domain.ReviewRepository
+import com.nexters.misik.feature.webview.BuildConfig
 import com.nexters.misik.webview.util.JsResponseUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -85,7 +86,7 @@ class WebViewViewModel @Inject constructor(
     fun getVersionUpdateStatus() {
         viewModelScope.launch {
             _state.value = WebViewState.PageLoading
-            reviewRepository.getVersionUpdateStatus(appVersion = "1.0.0", appPlatform = "ANDROID")
+            reviewRepository.getVersionUpdateStatus(appVersion = BuildConfig.VERSION_NAME, appPlatform = "ANDROID")
                 .onSuccess { data ->
                     if (data != null) {
                         val url = data.url

--- a/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/WebViewViewModel.kt
@@ -7,6 +7,7 @@ import com.nexters.misik.webview.util.JsResponseUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -20,6 +21,13 @@ class WebViewViewModel @Inject constructor(
 
     private val _responseJs = MutableStateFlow<String?>(null)
     val responseJs: StateFlow<String?> = _responseJs
+
+    private val _keyboardHeight = MutableStateFlow(0) // 키보드 높이 상태
+    val keyboardHeight: StateFlow<Int> = _keyboardHeight.asStateFlow()
+
+    fun updateKeyboardHeight(height: Int) {
+        _keyboardHeight.value = height
+    }
 
     fun sendIntent(intent: WebViewIntent) {
         when (intent) {

--- a/feature/webview/src/main/java/com/nexters/misik/webview/base/MisikWebViewFactory.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/base/MisikWebViewFactory.kt
@@ -26,7 +26,6 @@ object MisikWebViewFactory {
             addJavascriptInterface(webInterface, "AndroidBridge")
             webViewClient = MisikWebViewClient(onEvent)
             webChromeClient = MisikWebChromeClient()
-            loadUrl("https://misik-web.vercel.app/")
         }
     }
 }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/bridge/WebInterface.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/bridge/WebInterface.kt
@@ -6,6 +6,7 @@ import com.google.gson.JsonSyntaxException
 import com.nexters.misik.webview.WebViewIntent
 import com.nexters.misik.webview.bridge.dto.request.CopyRequest
 import com.nexters.misik.webview.bridge.dto.request.CreateReviewRequest
+import com.nexters.misik.webview.bridge.dto.request.ShareRequest
 import com.nexters.misik.webview.bridge.dto.request.toIntent
 import timber.log.Timber
 
@@ -27,8 +28,13 @@ class WebInterface(
     }
 
     @JavascriptInterface
-    fun share() {
-        eventCallback(WebViewIntent.Share)
+    fun share(json: String) {
+        try {
+            val request = gson.fromJson(json, ShareRequest::class.java)
+            eventCallback(WebViewIntent.Share(request.shareText))
+        } catch (e: JsonSyntaxException) {
+            Timber.e("JsonSyntaxException in share: ${e.message}")
+        }
     }
 
     @JavascriptInterface

--- a/feature/webview/src/main/java/com/nexters/misik/webview/bridge/dto/request/ShareRequest.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/bridge/dto/request/ShareRequest.kt
@@ -1,0 +1,5 @@
+package com.nexters.misik.webview.bridge.dto.request
+
+data class ShareRequest(
+    val shareText: String
+)

--- a/feature/webview/src/main/java/com/nexters/misik/webview/bridge/dto/request/ShareRequest.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/bridge/dto/request/ShareRequest.kt
@@ -1,5 +1,5 @@
 package com.nexters.misik.webview.bridge.dto.request
 
 data class ShareRequest(
-    val shareText: String
+    val shareText: String,
 )

--- a/feature/webview/src/main/java/com/nexters/misik/webview/util/JsResponseUtil.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/util/JsResponseUtil.kt
@@ -24,4 +24,11 @@ object JsResponseUtil {
         }
         return makeResponse(functionName, jsonResponse.toString())
     }
+
+    fun makeKeyboardHeightResponse(functionName: String, keyboardHeight: String?): String {
+        val jsonResponse = JSONObject().apply {
+            put("height", keyboardHeight ?: RESPONSE_FAILURE_MSG)
+        }
+        return makeResponse(functionName, jsonResponse.toString())
+    }
 }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/util/ShareUtil.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/util/ShareUtil.kt
@@ -9,19 +9,18 @@ object ShareUtil {
     /**
      * 기본 공유 기능 실행
      */
-    fun shareApp(context: Context) {
-        shareTextIntent(context)
+    fun shareApp(context: Context, shareText: String) {
+        shareTextIntent(context,shareText)
     }
 
     /**
      * 기본 텍스트 공유 기능
      */
-    private fun shareTextIntent(context: Context) {
+    private fun shareTextIntent(context: Context, shareText: String) {
         val title = context.getString(R.string.share_title)
-        val description = context.getString(R.string.share_description)
         val shareIntent = Intent(Intent.ACTION_SEND).apply {
             type = "text/plain"
-            putExtra(Intent.EXTRA_TEXT, description)
+            putExtra(Intent.EXTRA_TEXT, shareText)
         }
         context.startActivity(Intent.createChooser(shareIntent, title))
     }

--- a/feature/webview/src/main/java/com/nexters/misik/webview/util/ShareUtil.kt
+++ b/feature/webview/src/main/java/com/nexters/misik/webview/util/ShareUtil.kt
@@ -10,7 +10,7 @@ object ShareUtil {
      * 기본 공유 기능 실행
      */
     fun shareApp(context: Context, shareText: String) {
-        shareTextIntent(context,shareText)
+        shareTextIntent(context, shareText)
     }
 
     /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,8 +10,8 @@ targetSdk = "35"
 jdkVersion = "17"
 
 # App Versioning
-versionName = "1.0.3"
-versionCode = "4"
+versionName = "1.0.4"
+versionCode = "5"
 
 # Android Plugin Versions
 android-gradle-plugin = "8.8.0"

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -8,13 +8,8 @@ plugins {
 }
 
 android {
-    namespace = "com.hyeseon.misik.network"
-    buildFeatures {
-        buildConfig = true
-    }
-    defaultConfig {
-        buildConfigField("String", "NETWORK_BASE_URL", "\"https://api.misik.me/\"")
-    }
+    namespace = "com.nexters.misik.network"
+
 }
 
 dependencies {

--- a/network/src/main/java/com/nexters/misik/network/NetworkModule.kt
+++ b/network/src/main/java/com/nexters/misik/network/NetworkModule.kt
@@ -1,6 +1,5 @@
 package com.nexters.misik.network
 
-import com.hyeseon.misik.network.BuildConfig
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
 import dagger.Provides
@@ -85,7 +84,7 @@ object NetworkModule {
         @Logging client: OkHttpClient,
         converterFactory: Converter.Factory,
     ): Retrofit = Retrofit.Builder()
-        .baseUrl(BuildConfig.NETWORK_BASE_URL)
+        .baseUrl(BuildConfig.BASE_URL)
         .client(client)
         .addConverterFactory(converterFactory)
         .build()

--- a/network/src/main/java/com/nexters/misik/network/dto/response/GetVersionUpdateDto.kt
+++ b/network/src/main/java/com/nexters/misik/network/dto/response/GetVersionUpdateDto.kt
@@ -7,4 +7,4 @@ import kotlinx.serialization.Serializable
 data class GetVersionUpdateDto(
     @SerialName("url")
     val url: String?,
-    )
+)

--- a/network/src/main/java/com/nexters/misik/network/dto/response/GetVersionUpdateDto.kt
+++ b/network/src/main/java/com/nexters/misik/network/dto/response/GetVersionUpdateDto.kt
@@ -1,0 +1,10 @@
+package com.nexters.misik.network.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetVersionUpdateDto(
+    @SerialName("url")
+    val url: String?,
+    )

--- a/network/src/main/java/com/nexters/misik/network/service/ReviewService.kt
+++ b/network/src/main/java/com/nexters/misik/network/service/ReviewService.kt
@@ -35,7 +35,6 @@ interface ReviewService {
     @GET("/webview/home")
     suspend fun getUpdateStatus(
         @Header("app-version") appVersion: String,
-        @Header("app-platform") appPlatform: String
+        @Header("app-platform") appPlatform: String,
     ): Response<GetVersionUpdateDto>
-
 }

--- a/network/src/main/java/com/nexters/misik/network/service/ReviewService.kt
+++ b/network/src/main/java/com/nexters/misik/network/service/ReviewService.kt
@@ -3,9 +3,12 @@ package com.nexters.misik.network.service
 import com.nexters.misik.network.dto.request.GenerateReviewRequestDto
 import com.nexters.misik.network.dto.request.OcrParseRequestDto
 import com.nexters.misik.network.dto.response.GetReviewResponseDto
+import com.nexters.misik.network.dto.response.GetVersionUpdateDto
 import com.nexters.misik.network.dto.response.OcrParsedResponseDto
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
 
@@ -27,4 +30,12 @@ interface ReviewService {
     suspend fun getOcrParsedResponse(
         @Body request: OcrParseRequestDto,
     ): OcrParsedResponseDto
+
+    // 앱 버전 확인 후 url 반환 API
+    @GET("/webview/home")
+    suspend fun getUpdateStatus(
+        @Header("app-version") appVersion: String,
+        @Header("app-platform") appPlatform: String
+    ): Response<GetVersionUpdateDto>
+
 }


### PR DESCRIPTION
- closes #36 

## Description

- 강제업데이트 구현
  - 웹뷰 시작 시, 서버 요청해서 버전코드 비교 후 업데이트 필요하면 스토어 링크, 불필요하면 웹뷰 링크로 로드하도록 구현 (응답코드로 분기처리)
  - 버전코드는 플러그인 사용해서 BuildConfig로 가져와줌
- 공유하기 수정
  - 기존엔 네이티브에서 문구 하드코딩해주었는데, 웹에서 내려받아 동적으로 대응할수있도록 변경되어 해당 반영
- 키보드 높이 웹에게 전달
  - 클라 -> 웹 : receiveKeyboardHeight 추가하고, WindowInsets로 받아와서 높이 전달



## To Reviewers
- 기존에 서버 주소가 노출되어있더라구요, 커스텀플러그인-BuildConfig에 만들어뒀었는데 그게 사용안된거 같아서 해당 부분 지우고 local.properties에서 가져와 BuildConfig로 접근할 수 있도록 변경해주었습니다. ( 릴리즈 시에는 깃허브 시크릿에서 가져온 뒤 같은 흐름 )